### PR TITLE
the transform object should be told to only include js files

### DIFF
--- a/lib/aliasify.js
+++ b/lib/aliasify.js
@@ -20,7 +20,9 @@
     return null;
   };
 
-  module.exports = transformTools.makeRequireTransform("aliasify", function(args, opts, done) {
+  module.exports = transformTools.makeRequireTransform("aliasify", {
+    includeExtensions: ["js"]
+  }, function(args, opts, done) {
     var aliases, configDir, file, fileDir, replacement, result, verbose, _ref;
     if (!opts.config) {
       return done(new Error("Could not find configuration for aliasify"));

--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -11,7 +11,7 @@ getReplacement = (file, aliases)->
             return pkg+fileParts[2]
     return null
 
-module.exports = transformTools.makeRequireTransform "aliasify", (args, opts, done) ->
+module.exports = transformTools.makeRequireTransform "aliasify", includeExtensions: ["js"], (args, opts, done) ->
     if !opts.config then return done new Error("Could not find configuration for aliasify")
     aliases = opts.config.aliases
     verbose = opts.config.verbose

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -61,3 +61,18 @@ describe "aliasify", ->
             assert.equal result, expectedContent
             done()
 
+    it "passes anything that isn't javascript along", (done) ->
+        jsFile = path.resolve __dirname, "../testFixtures/test/package.json"
+        transformTools.runTransform aliasify, jsFile, (err, result) ->
+            return done err if err
+            assert.equal result, """{
+                "aliasify": {
+                    "aliases": {
+                        "d3": "./shims/d3.js",
+                        "underscore": "lodash"
+                    }
+                }
+            }
+            """
+            done()
+


### PR DESCRIPTION
While adding aliasify to my project it ran into issues with .json files I had in my build. Not sure if I should have added .coffee as well.
