### PR TITLE
Fix replacement paths that are absolute paths on Windows

### DIFF
--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -40,6 +40,6 @@ module.exports = transformTools.makeRequireTransform "aliasify", jsFilesOnly: tr
             else
                 replacement = replacement.replace(/\\/gi, "/")
 
-            result = "require('#{replacement.replace(/\\/gi,"/")}')"
+            result = "require('#{replacement}')"
 
     done null, result

--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -35,6 +35,11 @@ module.exports = transformTools.makeRequireTransform "aliasify", jsFilesOnly: tr
             if verbose
                 console.log "aliasify - #{opts.file}: replacing #{args[0]} with #{replacement}"
 
+            if /^[a-zA-Z]:\\/.test(replacement)
+                replacement = replacement.replace(/\\/gi, "\\\\")
+            else
+                replacement = replacement.replace(/\\/gi, "/")
+
             result = "require('#{replacement.replace(/\\/gi,"/")}')"
 
     done null, result

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -103,3 +103,23 @@ describe "aliasify", ->
             assert.equal result, expectedContent
             done()
 
+    it "should correctly resolve absolute paths", (done) ->
+        jsFile = path.resolve __dirname, "../testFixtures/test/src/foo/foo.js"
+
+        aliasifyWithConfig = aliasify.configure {
+            aliases: {
+                "foo": jsFile
+            }
+        }
+
+        content = """
+            foo = require("foo");
+        """
+        expectedContent = """
+            foo = require('#{jsFile.replace(/\\/gi, '\\\\')}');
+        """
+
+        transformTools.runTransform aliasifyWithConfig, jsFile, {content}, (err, result) ->
+            return done err if err
+            assert.equal result, expectedContent
+            done()


### PR DESCRIPTION
There is a bug where absolute paths on Windows have their backslashes replaced as forward slashes.  For relative paths, this is not a problem.  However, especially with joeybaker/remapify, it is possible to have absolute paths passed into aliasify, and getting the backslashes replaced there is problematic.

This fixes the issue by testing for an absolute path on Windows, and then replacing backslashes with double backslashes, which is necessary since the filename is in quotes.  All other paths have their backslashes replaced by forward slashes as currently happens today.  This also adds a new test for absolute paths to ensure the change is working properly.