### PR TITLE
Use console.error to log verbose message

### DIFF
--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -33,7 +33,7 @@ module.exports = transformTools.makeRequireTransform "aliasify", {jsFilesOnly: t
                 replacement = "./#{path.relative fileDir, replacement}"
 
             if verbose
-                console.log "aliasify - #{opts.file}: replacing #{args[0]} with #{replacement}"
+                console.error "aliasify - #{opts.file}: replacing #{args[0]} with #{replacement}"
 
             result = "require('#{replacement.replace(/\\/gi,"/")}')"
 


### PR DESCRIPTION
So that when using pipes, e.g. `browserify file.js | command2 > bundle.js`,
the verbose message doesn't end up in the output bundle.