### PR TITLE
More powerful replacement using Regex strings and functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ regardless of where those files are in the directory tree.
 
 Regular Expression Aliasing
 ===========================
-You can use the `replacements` configuration section to create more powerful aliasing.  This can be especially useful if you
-have a large project but don't want to manually add an alias for every single file.  It is also useful when you want to combine
-aliasify with other teansforms, such as hbsfy, reactify, or coffeeify.
+You can use the `replacements` configuration section to create more powerful aliasing.  This is useful if you
+have a large project but don't want to manually add an alias for every single file.  It is also incredibly useful when you want to combine
+aliasify with other transforms, such as hbsfy, reactify, or coffeeify.
 
     replacements: {
         "_components/(\\w+)": "src/react/components/$1/index.jsx

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ directory.
 
 Configuration options:
 * `aliases` - An object mapping aliases to their replacements.
+* `replacements` - An object mapping RegExp strings with RegExp replacements, or a function that will return a replacement.
 * `verbose` - If true, then aliasify will print modificiations it is making to stdout.
 * `configDir` - An absolute path to resolve relative paths against.  If you're using package.json, this will automatically be filled in for you with the directory containing package.json.  If you're using a .js file for configuration, set this to `__dirname`.
 * `appliesTo` - Controls which files will be transformed.  By default, only JS type files will be transformed ('.js', '.coffee', etc...).  See [browserify-trasnform-tools documentation](https://github.com/benbria/browserify-transform-tools/wiki/Transform-Configuration#common-configuration) for details.
@@ -94,6 +95,32 @@ relative to the file which is doing the `require` call.  In this case you can do
 
 This will cause all occurences of `require("d3")` to be replaced with `require("./shims/d3.js")`,
 regardless of where those files are in the directory tree.
+
+Regular Expression Aliasing
+===========================
+You can use the `replacements` configuration section to create more powerful aliasing.  This can be especially useful if you
+have a large project but don't want to manually add an alias for every single file.  It is also useful when you want to combine
+aliasify with other teansforms, such as hbsfy, reactify, or coffeeify.
+
+    replacements: {
+        "_components/(\\w+)": "src/react/components/$1/index.jsx
+    }
+
+Will let you replace `require('_components/SomeCoolReactComponent')` with `require('src/react/components/SomeCoolReactComponent/index.js')`
+
+You can also match an alias and pass a function which can return a new file name.
+
+`require("_coffee/delicious-coffee");`
+
+Using this configuration:
+    replacements: {
+        "_coffee/(\\w+)": function (alias, regexMatch, regexObject) {
+            console.log(alias); // _coffee/delicious-coffee
+            console.log(regexMatch); // _coffee/(\\w+)
+            return 'coffee.js'; // default behavior - won't replace
+        }
+    }
+
 
 
 Alternatives

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ You can also match an alias and pass a function which can return a new file name
 `require("_coffee/delicious-coffee");`
 
 Using this configuration:
+
     replacements: {
         "_coffee/(\\w+)": function (alias, regexMatch, regexObject) {
             console.log(alias); // _coffee/delicious-coffee

--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -5,7 +5,10 @@ getReplacement = (file, aliases, regexps)->
     for key of regexps
         re = new RegExp(key)
         if re.test(file)
-            return file.replace(re, regexps[key])
+            if typeof regexps[key] == "Function"
+                return regexps[key](key, file, re)
+            else
+                return file.replace(re, regexps[key])
 
     if aliases[file]
         return aliases[file]
@@ -22,6 +25,7 @@ module.exports = transformTools.makeRequireTransform "aliasify", {jsFilesOnly: t
     aliases = opts.config.aliases
     regexps = opts.config.replacements
     verbose = opts.config.verbose
+
     configDir = opts.configData?.configDir or opts.config.configDir or process.cwd()
 
     result = null

--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -5,7 +5,7 @@ getReplacement = (file, aliases, regexps)->
     for key of regexps
         re = new RegExp(key)
         if re.test(file)
-            if typeof regexps[key] == "Function"
+            if typeof regexps[key] == "function"
                 return regexps[key](file, key, re)
             else
                 return file.replace(re, regexps[key])

--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -6,7 +6,7 @@ getReplacement = (file, aliases, regexps)->
         re = new RegExp(key)
         if re.test(file)
             if typeof regexps[key] == "Function"
-                return regexps[key](key, file, re)
+                return regexps[key](file, key, re)
             else
                 return file.replace(re, regexps[key])
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -197,3 +197,21 @@ describe "aliasify", ->
             return done err if err
             assert.equal result, expectedContent
             done()
+
+    it "should correctly replace a RexExp alias function", (done) ->
+        jsFile = path.resolve __dirname, "../testFixtures/test/src/regexp.js"
+        aliasifyWithConfig = aliasify.configure {
+            replacements: {
+                "_components/(\\w+)": (alias, file, re) ->
+                    return "src/silly.js"
+            }
+        }
+
+        expectedContent = Mocha.utils.clean("""
+            SomeComponent = require('src/silly.js');
+        """)
+
+        transformTools.runTransform aliasifyWithConfig, jsFile, (err, result) ->
+            return done err if err
+            assert.equal result, expectedContent
+            done()

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,7 +1,7 @@
 path = require 'path'
 assert = require 'assert'
 transformTools = require 'browserify-transform-tools'
-
+Mocha = require 'mocha'
 aliasify = require '../src/aliasify'
 testDir = path.resolve __dirname, "../testFixtures/test"
 testWithRelativeConfigDir = path.resolve __dirname, "../testFixtures/testWithRelativeConfig"
@@ -17,10 +17,10 @@ describe "aliasify", ->
         jsFile = path.resolve __dirname, "../testFixtures/test/src/index.js"
         transformTools.runTransform aliasify, jsFile, (err, result) ->
             return done err if err
-            assert.equal result, """
+            assert.equal Mocha.utils.clean(result), Mocha.utils.clean("""
                 d3 = require('./../shims/d3.js');
                 _ = require('lodash');
-            """
+            """)
             done()
 
     it "should correctly transform a file when the configuration is in a different directory", (done) ->
@@ -42,10 +42,10 @@ describe "aliasify", ->
 
         transformTools.runTransform aliasify, jsFile, {config: aliasifyConfig}, (err, result) ->
             return done err if err
-            assert.equal result, """
+            assert.equal Mocha.utils.clean(result), Mocha.utils.clean("""
                 d3 = require('./../foo/baz.js');
                 _ = require("underscore");
-            """
+            """)
             done()
 
     it "should allow configuration to be specified using legacy 'configure' method", (done) ->
@@ -59,10 +59,10 @@ describe "aliasify", ->
 
         transformTools.runTransform aliasifyWithConfig, jsFile, (err, result) ->
             return done err if err
-            assert.equal result, """
+            assert.equal Mocha.utils.clean(result), Mocha.utils.clean("""
                 d3 = require('./../foo/bar.js');
                 _ = require("underscore");
-            """
+            """)
             done()
 
     it "should allow paths after an alias", (done) ->
@@ -75,12 +75,12 @@ describe "aliasify", ->
             configDir: path.resolve __dirname, "../testFixtures/test"
         }
 
-        content = """
+        content = Mocha.utils.clean("""
             d3 = require("d3/bar.js");
-        """
-        expectedContent = """
+        """)
+        expectedContent = Mocha.utils.clean("""
             d3 = require('./../foo/bar.js');
-        """
+        """)
 
         transformTools.runTransform aliasifyWithConfig, jsFile, {content}, (err, result) ->
             return done err if err
@@ -91,7 +91,7 @@ describe "aliasify", ->
         jsFile = path.resolve __dirname, "../testFixtures/test/package.json"
         transformTools.runTransform aliasify, jsFile, (err, result) ->
             return done err if err
-            assert.equal result, """{
+            assert.equal Mocha.utils.clean(result), Mocha.utils.clean("""{
                 "aliasify": {
                     "aliases": {
                         "d3": "./shims/d3.js",
@@ -99,7 +99,7 @@ describe "aliasify", ->
                     }
                 }
             }
-            """
+            """)
             done()
 
     it "passes supports relative path option", (done) ->
@@ -111,9 +111,9 @@ describe "aliasify", ->
             }
         }
 
-        expectedContent = """
+        expectedContent = Mocha.utils.clean("""
             var foo = require('../foo/foo.js');
-        """
+        """)
 
         transformTools.runTransform aliasifyWithConfig, jsFile, (err, result) ->
             return done err if err
@@ -131,10 +131,10 @@ describe "aliasify", ->
         jsFile = path.resolve __dirname, "../testFixtures/react/includeReact.js"
         transformTools.runTransform aliasify, jsFile, (err, result) ->
             return done err if err
-            assert.equal result, """
+            assert.equal Mocha.utils.clean(result), Mocha.utils.clean("""
                 react1 = require('react/addons');
                 react2 = require('react/addons');
-            """
+            """)
             done()
 
     it "should correctly resolve Windows absolute paths", (done) ->
@@ -146,14 +146,14 @@ describe "aliasify", ->
             }
         }
 
-        content = """
+        content = Mocha.utils.clean("""
             foo = require("foo");
-        """
+        """)
         # Note the \\\\ here, because this is in "s, but this resolves to a double \\.
         # The double \\ is still needed, since \\ inside of ''s resolves to a single \ in the end.
-        expectedContent = """
+        expectedContent = Mocha.utils.clean("""
             foo = require('c:\\\\foo.js');
-        """
+        """)
 
         transformTools.runTransform aliasifyWithConfig, jsFile, {content}, (err, result) ->
             return done err if err
@@ -169,12 +169,12 @@ describe "aliasify", ->
             }
         }
 
-        content = """
+        content = Mocha.utils.clean("""
             foo = require("foo");
-        """
-        expectedContent = """
+        """)
+        expectedContent = Mocha.utils.clean("""
             foo = require('#{jsFile.replace(/\\/gi, '\\\\')}');
-        """
+        """)
 
         transformTools.runTransform aliasifyWithConfig, jsFile, {content}, (err, result) ->
             return done err if err

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -215,3 +215,25 @@ describe "aliasify", ->
             return done err if err
             assert.equal result, expectedContent
             done()
+
+    it "should correctly replace multiple RexExp alias functions (scoping)", (done) ->
+        jsFile = path.resolve __dirname, "../testFixtures/test/src/regexp2.js"
+        aliasifyWithConfig = aliasify.configure {
+            replacements: {
+                "_component/(.*)": (alias, regexMatcher, regexObject) ->
+                    return alias.replace(regexObject, 'src/silly.js')
+                "_store/(.*)": (alias, regexMatcher, regexObject) ->
+                    return alias.replace(regexObject, 'src/stores/$1/index.js')
+
+            }
+        }
+
+        expectedContent = Mocha.utils.clean("""
+            SomeComponent = require('src/silly.js');
+            SomeStore = require('src/stores/SomeStore/index.js');
+        """)
+
+        transformTools.runTransform aliasifyWithConfig, jsFile, (err, result) ->
+            return done err if err
+            assert.equal Mocha.utils.clean(result), expectedContent
+            done()

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -180,3 +180,20 @@ describe "aliasify", ->
             return done err if err
             assert.equal result, expectedContent
             done()
+
+    it "should correctly replace a RexExp alias", (done) ->
+        jsFile = path.resolve __dirname, "../testFixtures/test/src/regexp.js"
+        aliasifyWithConfig = aliasify.configure {
+            replacements: {
+                "_components/(\\w+)": "src/components/$1.jsx"
+            }
+        }
+
+        expectedContent = Mocha.utils.clean("""
+            SomeComponent = require('src/components/SomeComponent.jsx');
+        """)
+
+        transformTools.runTransform aliasifyWithConfig, jsFile, (err, result) ->
+            return done err if err
+            assert.equal result, expectedContent
+            done()

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -202,7 +202,7 @@ describe "aliasify", ->
         jsFile = path.resolve __dirname, "../testFixtures/test/src/regexp.js"
         aliasifyWithConfig = aliasify.configure {
             replacements: {
-                "_components/(\\w+)": (alias, file, re) ->
+                "_components/(\\w+)": (alias, regexMatcher, regexObject) ->
                     return "src/silly.js"
             }
         }

--- a/testFixtures/test/src/regexp.js
+++ b/testFixtures/test/src/regexp.js
@@ -1,0 +1,1 @@
+SomeComponent = require("_components/SomeComponent");

--- a/testFixtures/test/src/regexp2.js
+++ b/testFixtures/test/src/regexp2.js
@@ -1,0 +1,2 @@
+SomeComponent = require("_component/SomeComponent");
+SomeStore = require("_store/SomeStore");


### PR DESCRIPTION
This PR allows developers to write simple rules in lieu of longer, explicit search-and-replace manifests for aliasify.  While at its simplest, it could be just a replacement for something like pathify, the power comes from being able to chain aliasify with other transforms such as coffiefy, hbsfy, reactify etc.

### Example
```javascript
// in a gulp file that configures browserify bundlers...
var aliasify = require('aliasify').configure({
    // Typical alias
    aliases: {
        '_env/config':      './src/config/' + process.env.NODE_ENV,
    },
    replacements: {
        '_lib/(\\w+)':         './src/js/lib/$1.js',
        '_third-party/(\\w+)': './contrib/$1.js',

        // I've decided to modularize my React components and use a common file naming convention...
        '_component/(\\w+)':  './components/$1/index.jsx', // reactify will parse this later.
        '_dispatcher/(\\w+)':  './dispatchers/$1.js',

        // I have inhereted a bunch of DAO objects with legacy naming.
        '_dao/(\\w+)': function (alias, regexMatch, regexObject) {
            return alias.replace(regexObject, 'src/js/dao/dao_$1.coffee');
        }
    },
    configDir: path.join(__dirname, '..', '..'),
    verbose: false
});
```

#### Notes
While this seems to overlap with other transforms such as pathmodify, I have found that many of these to have archaic configurations and plugin configurations.  I needed simple rules to replace an alias.  I couldn't find a module that did it, and I am already using aliasify.  Thus, this PR :)