### PR TITLE
feat(requireAliases): new function "requireish" accepts aliases for require

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Stubbing Out Packages
 You can remove a package entirely for browser builds using:
 
     aliases: {
-        "d3": "./shims/d3.js"
+        "d3": false
     }
 
 Now any code which tries to `require('d3')` will end up compiling to:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,29 @@ Now any code which tries to `require('d3')` will end up compiling to:
 
     var d3 = {};
 
+
+Support aliasing requireish function calls
+=====================
+
+You can tell aliasify to also replace aliases in other functions than `require`. This can become very helpful if you are planing on wrap
+node's require function with another one. For example in case of [proxyquireify](https://github.com/thlorenz/proxyquireify) this is very helpful.
+
+```JavaScript
+    var aliasify = require("aliasify").requireish(["foo", "bar"])
+```
+
+with this options:
+
+    aliases: {
+            "d3": {"relative": "./shims/d3.js"}
+        }
+
+Now any code which tries to `require('d3')` or `foo('d3')` or even `bar('d3')` will end up compiling to:
+
+`require("./shims/d3.js")` respectively `foo("./shims/d3.js")` respectively `bar("./shims/d3.js")`
+
+NOTE: The argument for `requireish()` can be either a string or an array of strings. Also note that the function does not modifiy an aliasify instance, it returns a complete new one! Another important thing to know is that aliasify only replaces the first string parameter of the "requireish" function call. All other arguments are preserved as they were passed in. Caution! Do NOT pass in arguments that have circular references. If you need that, than just pass in an identifier for the object having circular references!
+
 Alternatives
 ============
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "browserify-transform-tools": "~1.5.1"
+    "browserify-transform-tools": "~1.5.4"
   },
   "devDependencies": {
     "coffee-coverage": "^0.7.0",

--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -1,6 +1,8 @@
 path = require 'path'
 transformTools = require 'browserify-transform-tools'
 
+requireAliases = ['require']
+
 # Returns replacement require, `null` to not change require, `false` to replace require with `{}`.
 getReplacement = (file, aliases, regexps) ->
     if regexps?
@@ -28,40 +30,74 @@ getReplacement = (file, aliases, regexps) ->
 
     return null
 
-module.exports = transformTools.makeRequireTransform "aliasify", {jsFilesOnly: true, fromSourceFileDir: true}, (args, opts, done) ->
-    if !opts.config then return done new Error("Could not find configuration for aliasify")
-    aliases = opts.config.aliases
-    regexps = opts.config.replacements
-    verbose = opts.config.verbose
+makeTransform = () ->
+    transformTools.makeFunctionTransform "aliasify", {jsFilesOnly: true, fromSourceFileDir: true, functionNames: requireAliases}, (functionParams, opts, done) ->
+        if !opts.config then return done new Error("Could not find configuration for aliasify")
+        aliases = opts.config.aliases
+        regexps = opts.config.replacements
+        verbose = opts.config.verbose
+    
+        configDir = opts.configData?.configDir or opts.config.configDir or process.cwd()
+    
+        result = null
 
-    configDir = opts.configData?.configDir or opts.config.configDir or process.cwd()
+        file = functionParams.args[0].value
+        if file? and (aliases? or regexps?)
+            replacement = getReplacement(file, aliases, regexps)
+            if replacement == false
+                result = "{}"
+            else if replacement?
+                if replacement.relative?
+                    replacement = replacement.relative
 
-    result = null
+                else if /^\./.test(replacement)
+                    # Resolve the new file relative to the configuration file.
+                    replacement = path.resolve configDir, replacement
+                    fileDir = path.dirname opts.file
+                    replacement = "./#{path.relative fileDir, replacement}"
 
-    file = args[0]
-    if file? and (aliases? or regexps?)
-        replacement = getReplacement(file, aliases, regexps)
-        if replacement == false
-            result = "{}"
-        else if replacement?
-            if replacement.relative?
-                replacement = replacement.relative
+                if verbose
+                    console.error "aliasify - #{opts.file}: replacing #{file} with #{replacement} of function #{functionParams.name}"
 
-            else if /^\./.test(replacement)
-                # Resolve the new file relative to the configuration file.
-                replacement = path.resolve configDir, replacement
-                fileDir = path.dirname opts.file
-                replacement = "./#{path.relative fileDir, replacement}"
+                # If this is an absolute Windows path (e.g. 'C:\foo.js') then don't convert \s to /s.
+                if /^[a-zA-Z]:\\/.test(replacement)
+                    replacement = replacement.replace(/\\/gi, "\\\\")
+                else
+                    replacement = replacement.replace(/\\/gi, "/")
 
-            if verbose
-                console.error "aliasify - #{opts.file}: replacing #{args[0]} with #{replacement}"
+                result = "'#{replacement}'"
 
-            # If this is an absolute Windows path (e.g. 'C:\foo.js') then don't convert \s to /s.
-            if /^[a-zA-Z]:\\/.test(replacement)
-                replacement = replacement.replace(/\\/gi, "\\\\")
-            else
-                replacement = replacement.replace(/\\/gi, "/")
+        
+        # Check if the function has more than one arg. If so preserve the remaining ones.
+        if result? and result isnt "{}"
+            remainingArgs = functionParams.args.slice(1);
+            if remainingArgs.length > 0
+                for arg in remainingArgs
+                    if arg.type is "Literal"
+                        result += ", '#{arg.value}'"
+                    else if arg.type is "ObjectExpression"
+                        try 
+                            result += ", #{JSON.stringify arg.value}"
+                        catch err
+                            result += ", #{JSON.stringify {}}"
+                    else if arg.type is "ArrayExpression"
+                        try
+                            result += ", #{JSON.stringify arg.value}"
+                        catch err
+                            result += ", #{JSON.stringify []}"
+                    else
+                        result += ", #{arg.value}"
+            result = "#{functionParams.name}(#{result})"
+        
+        done null, result
 
-            result = "require('#{replacement}')"
+module.exports = makeTransform();
 
-    done null, result
+module.exports.requireish = (aliases) ->
+    if Array.isArray(aliases) || {}.toString.call(aliases) is "[object Array]"
+        for alias in aliases
+            requireAliases.push alias
+    else if typeof aliases is "string"
+        requireAliases.push aliases
+
+    makeTransform()

--- a/testFixtures/test/src/foobar/foobar.js
+++ b/testFixtures/test/src/foobar/foobar.js
@@ -1,0 +1,2 @@
+var foo = foobar('foo');
+var qux = baz('foo');


### PR DESCRIPTION
Third try :D

I hope that I haven't forgot something again this time.
The new function accepts either a string or an array of strings as require aliases.
It is tested and documented.

The CI build will obviously fail because aliasify depends on browserify-transform-tools version 1.5.4+ which is not published yet. This will optimally happen if my PR in the other repo gets accepted too.
