### PR TITLE
new config option "absolutePaths", new exposed method "getReplacement", update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ relative to the file which is doing the `require` call.  In this case you can do
 This will cause all occurences of `require("d3")` to be replaced with `require("./shims/d3.js")`,
 regardless of where those files are in the directory tree.
 
+Absolute Replacements
+=================
+
+When you specify:
+
+    aliases: {
+        "d3": "./shims/d3.js"
+    },
+    absolutePaths: true
+
+
+This will cause all occurences of `require("d3")` to be replaced with `require("[absolute path to d3.js]")`,
+regardless of where those files are in the directory tree.
+
 Regular Expression Aliasing
 ===========================
 You can use the `replacements` configuration section to create more powerful aliasing.  This is useful if you
@@ -147,28 +161,54 @@ You can tell aliasify to also replace aliases in other functions than `require`.
 node's require function with another one. For example in case of [proxyquireify](https://github.com/thlorenz/proxyquireify) this is very helpful.
 
 ```JavaScript
-    var aliasify = require("aliasify").requireish(["require", "foo", "bar"])
+    var aliasify = require("aliasify");
 ```
 
 with this options:
 
     aliases: {
-            "d3": {"relative": "./shims/d3.js"}
-        }
+            "d3": "./shims/d3.js"
+        },
+    requireish: ["require", "foo", "bar"]
 
 Now any code which tries to `require('d3')` or `foo('d3')` or even `bar('d3')` will end up compiling to:
 
 `require("./shims/d3.js")` respectively `foo("./shims/d3.js")` respectively `bar("./shims/d3.js")`
 
-The argument for `requireish()` can be either a string or an array of strings.
+The argument for `requireish` can be either a string or an array of strings.
 
 A few things to note: first, if you specify `requireish`, you must explicitly list `require` in the list of requireish
 things to transform, or it won't be.
 
 Second, note that aliasify only replaces the first string parameter of the "requireish" function call. All other
-arguments are preserved as they were passed in. (e.g. `require('d3', 'foo')` turns into
+arguments are preserved as they were passed in. (e.g. `require('d3', 'foo')` gets transformed to
 `require('./shims/d3.js', 'foo')`.)  Caution! Do NOT pass in arguments that have circular references. If you need that,
 than just pass in an identifier for the object having circular references!
+
+
+Manually get absolute replacement path
+=====================
+
+You can manually get the absolute path to a replacement from an alias:
+
+```JavaScript
+    var aliasify = require("aliasify");
+
+    var aliasifyConfig = {
+      aliases: {
+                  "d3": "./shims/d3.js"
+              }
+    }
+
+    var path = aliasify.getReplacement("d3", aliasifyConfig);
+```
+
+Now `path` is the absolute path to `d3.js`.
+If no replacement is found the function returns `false`.
+
+Note that the manual method just concatenates `configDir` with the matching entry in `aliases` or `replacement` part from the aliasify config you pass in.
+In order to work properly you have to ensure that this concatenation (through `path.resolve`) makes sense, *e.g.* `configDir = [projectRoot]` and aliases part from the config has entries relative from this `configDir`.
+
 
 Alternatives
 ============

--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -40,6 +40,7 @@ makeTransform = (requireAliases) ->
         aliases = opts.config.aliases
         regexps = opts.config.replacements
         verbose = opts.config.verbose
+        absolutePaths = opts.config.absolutePaths
 
         configDir = opts.configData?.configDir or opts.config.configDir or process.cwd()
 
@@ -55,10 +56,11 @@ makeTransform = (requireAliases) ->
                     replacement = replacement.relative
 
                 else if /^\./.test(replacement)
-                    # Resolve the new file relative to the configuration file.
+                    # Resolve the new file relative to the configuration file or system absolute
                     replacement = path.resolve configDir, replacement
-                    fileDir = path.dirname opts.file
-                    replacement = "./#{path.relative fileDir, replacement}"
+                    if !absolutePaths
+                        fileDir = path.dirname opts.file
+                        replacement = "./#{path.relative fileDir, replacement}"
 
                 if verbose
                     console.error "aliasify - #{opts.file}: replacing #{file} with #{replacement} " +

--- a/src/aliasify.coffee
+++ b/src/aliasify.coffee
@@ -112,3 +112,15 @@ module.exports = (file, config) ->
 
 module.exports.configure = (config) ->
     return (file) -> module.exports file, config
+
+module.exports.getReplacement = (alias, config) ->
+    if !config then return new Error("Could not find configuration for aliasify")
+    aliases = config.aliases
+    regexps = config.replacements
+
+    replacement = getReplacement alias, aliases, regexps
+    if replacement?
+        configDir = config.configDir or process.cwd()
+        path.resolve configDir, replacement
+    else
+        false

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -50,7 +50,6 @@ describe "aliasify", ->
             done()
 
     it "should load requireish options from config", (done) ->
-        console.log requireishConfigDir
         process.chdir requireishConfigDir
         jsFile = path.resolve requireishConfigDir, "foobar.js"
         transformTools.runTransform aliasify, jsFile, (err, result) ->
@@ -66,6 +65,15 @@ describe "aliasify", ->
         .then (result) ->
             assert.equal Mocha.utils.clean(result), Mocha.utils.clean("""
                 d3 = require('./../foo/baz.js');
+                _ = require("underscore");
+            """)
+
+    it "should allow setting the replacement path absolute", ->
+        absolutePath = path.resolve process.cwd(), './foo/baz.js'
+        runTestWithConfig {aliases: {"d3": "./foo/baz.js"}, absolutePaths: true}
+        .then (result) ->
+            assert.equal Mocha.utils.clean(result), Mocha.utils.clean("""
+                d3 = require('#{absolutePath}');
                 _ = require("underscore");
             """)
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -367,3 +367,8 @@ describe "aliasify", ->
             assert.equal Mocha.utils.clean(result), Mocha.utils.clean("""
                 var foo = foobar('../foo/foo.js', 'baz', bar, function (){}, {}, []);
             """)
+
+    it "should return the right absolute path through the getReplacement method", ->
+        absolutePath = path.resolve process.cwd(), './foo/baz.js'
+        path = aliasify.getReplacement "d3", {aliases: {"d3": "./foo/baz.js"}}
+        assert.equal Mocha.utils.clean(path), Mocha.utils.clean(absolutePath)


### PR DESCRIPTION
Hi jwalton,

first of all thank you  for the recent collaboration on `requireish`. It was really fun and productive ;)

I wanted to implement the new functionality in my project and faced new problems. I generally think, that it is not a good idea to replace the aliases with relative paths. There is no argument against replacing them always with absolute ones.

This was very crucial when I tried to use `proxyquierify`with `aliasify`. Let me explain the scenario:
With `proxyquireify` you are able to stub out arbitrary required modules. The problem here is... If you require a module through an alias in the **original** file which gehts replaced through a relative path from `aliasify` you are not longer able to stub out this package because the require path for that module was manipulated and can not longer be stubbed out with the alias.

Here comes a second problem in play. There is no method to manually get the replacement for an alias. I have to programmatically get the replacement path for the alias I want to stub out what is now possible with the new method `getReplacement`. 

Now the absolute paths are important because the stubbed out path in the `proxyquireify` stubs has to match the replaced require path in the original file. This is nearly impossible if you have your spec files in a completely different folder than your src files.

Last but not least I updated the README with the new functionalities and edited the `requireish` part which was not exactly correct.